### PR TITLE
small fix in adapter_idb, causing callback to be missing

### DIFF
--- a/modules/pouchdb_adapter_idb/mod.ts
+++ b/modules/pouchdb_adapter_idb/mod.ts
@@ -21,7 +21,6 @@ function IDBDenoWrapper(pouchDb: PouchDB.Static): void {
   adapterIdb.use_prefix = false;
 
   function idb(
-    this: any,
     opts: PouchDB.IdbAdapter.IdbAdapterConfiguration,
     callback: any,
   ) {


### PR DESCRIPTION
I was getting a stack of errors (below) related to a missing callback, when running your couch port in the browser.
Although I don't think browser usage was your intent I wanted to see if I could get it working.

That said, I'm also importing this modified version of your port for a node-side instance of couch and it seems to be ok.

From what I could see, declaring `this` as an arg in the function being run via `call` was causing the arguments to shift, so that the value of `this` was the options and  the value of `opts` was the callback (for me anyways). 

This change seems to have unblocked things and I can now see the db created in the "browser storage inspector" (firefox).

The error(s):
Uncaught TypeError: fun is not a function
    tryCode pouchdb-adapter-idb.js:786
    runCallback pouchdb-adapter-idb.js:801
    completeSetup pouchdb-adapter-idb.js:1511
    oncomplete pouchdb-adapter-idb.js:1543
    onsuccess pouchdb-adapter-idb.js:1541
    init pouchdb-adapter-idb.js:1476
    IdbPouch pouchdb-adapter-idb.js:969
    runAction pouchdb-adapter-idb.js:800
    applyNext pouchdb-adapter-idb.js:796
    enqueueTask pouchdb-adapter-idb.js:808
    IdbPouch pouchdb-adapter-idb.js:968
    idb mod.ts:41
    PouchDB pouchdb-core.js:1401

